### PR TITLE
SHOP-17012: add "disabled" class for button

### DIFF
--- a/desktop/components/_buttons.scss
+++ b/desktop/components/_buttons.scss
@@ -73,7 +73,8 @@ This gives a button the shape and coolness it deserves for being a button in a Z
         }
     }
 
-    &:disabled {
+    &:disabled,
+    &.disabled {
         opacity: 0.5;
         color: $colorDarkDisabled;
     }
@@ -128,7 +129,8 @@ category: Buttons
             }
         }
 
-        &:disabled {
+        &:disabled,
+        &.disabled {
             color: $colorDarkDisabled;
         }
     }
@@ -143,7 +145,8 @@ category: Buttons
             color: $colorDarkPrimary;
         }
 
-        &:disabled {
+        &:disabled,
+        &.disabled {
             color: $colorLightPrimary;
         }
     }
@@ -158,7 +161,8 @@ category: Buttons
             color: $colorDarkSecondary;
         }
 
-        &:disabled {
+        &:disabled,
+        &.disabled {
             color: $colorLightDisabled;
         }
     }


### PR DESCRIPTION
I add this class because in some cases, we create a button with an `<a>` tag instead of a `button` tag.